### PR TITLE
Fix issues with hidden checkbox and some sites doesn't have .h-captcha element

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ export const solveCaptcha = async (
 
     const sitekey = findURLParam(new URLSearchParams(innerFrame.url()), key =>
       key.includes('sitekey')
-    );
+    )[1];
 
     await innerFrame.waitForSelector('.challenge-container', { timeout: 10 * 1000 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,8 @@ export const solveCaptcha = async (
   if (!innerFrame) throw new Error('solveCaptcha: captcha inner frame not found');
 
   const checkbox = await outerFrame.waitForSelector('#checkbox');
-  await checkbox?.click();
+
+  if (!(await innerFrame.$('.challenge'))) await checkbox?.click();
 
   // await sleep(500000); // debug waiting
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import type { Page } from 'puppeteer';
 import { getImages } from './images';
 import { getTarget } from './target';
 import { randTimer, subscriptionType } from './type';
-import { getApiUrl, sleep } from './utils';
+import { findURLParam, getApiUrl, sleep } from './utils';
 
 /**
  * Solve captchas using `nocaptchaai.com` API service
@@ -40,7 +40,9 @@ export const solveCaptcha = async (
 
     if (debug) console.log('🌍 Language found = ', language);
 
-    const sitekey = await page.$eval('.h-captcha', el => el.getAttribute('data-sitekey'));
+    const sitekey = findURLParam(new URLSearchParams(innerFrame.url()), key =>
+      key.includes('sitekey')
+    );
 
     await innerFrame.waitForSelector('.challenge-container', { timeout: 10 * 1000 });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,3 +5,21 @@ export const sleep = async (ms: number): Promise<void> =>
 
 export const getApiUrl = (type: subscriptionType): string =>
   `https://${type}.nocaptchaai.com/api/solve`;
+
+/**
+ * Find URL param
+ * @param params Your URL params
+ * @param callback Callback that called every record in params
+ * @returns [key, value]
+ */
+export const findURLParam = (
+  params: URLSearchParams,
+  callback: (key: string, value: string, index: number, params: URLSearchParams) => unknown
+): [string, string] => {
+  /* eslint-disable @typescript-eslint/no-non-null-assertion */
+  const key = Array.from(params.keys()).find((key, index) =>
+    callback(key, params.get(key)!, index, params)
+  )!;
+  return [key, params.get(key)!];
+  /* eslint-enable @typescript-eslint/no-non-null-assertion */
+};


### PR DESCRIPTION
While developing my app I have encountered 2 errors.
The first one is that some websites didn't had any captcha checkboxes.
 - They actually had it, but it was hidden, and the puppeteer just couldn't click on the checkbox, and the script just got stuck at that point, so I added a check if interFrame already visible.

And second one, on some sites there is no .h-captcha element through which we get the sitekey.
 - I found another way to get the sitekey. The src link from Inter frame has the sitekey parameter which already has the value we need, but then it turned out that on some sites the sitekey had some kind of prefix, so I created a function to search parameters in the url.